### PR TITLE
Prevent indefinite IAS App recreation in case k8s secret creation fails

### DIFF
--- a/api/v1alpha1/eventingauth_types.go
+++ b/api/v1alpha1/eventingauth_types.go
@@ -67,6 +67,7 @@ type AuthSecret struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 
 // EventingAuth is the Schema for the eventingauths API
 type EventingAuth struct {

--- a/config/crd/bases/operator.kyma-project.io_eventingauths.yaml
+++ b/config/crd/bases/operator.kyma-project.io_eventingauths.yaml
@@ -15,7 +15,11 @@ spec:
     singular: eventingauth
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: EventingAuth is the Schema for the eventingauths API

--- a/controllers/eventingauth_controller_test.go
+++ b/controllers/eventingauth_controller_test.go
@@ -78,6 +78,10 @@ var _ = Describe("EventingAuth Controller", Serial, func() {
 		It("should retry and create secret when first attempt of secret creation failed", func() {
 			// TODO: Implement test
 		})
+
+		It("should not recreate IAS application if it exists in reconciler cache", func() {
+			// TODO: Implement test
+		})
 	})
 
 })


### PR DESCRIPTION

**Description**
Prevents indefinite IAS app recreation due to status change with IAS application UUID. 
Changes proposed in this pull request:

- Prevents indefinite IAS app recreation due to status change with IAS application UUID. 
- Add print column to status.state
- Remove duplicate log details